### PR TITLE
modify the way to apply_layer() function

### DIFF
--- a/relaxations.py
+++ b/relaxations.py
@@ -244,7 +244,7 @@ class Zonotope:
             scipy.linalg.null_space(difference_zonotope_np).T)
 
         num_affine_relations = affine_relations.shape[0]
-        assert(num_affine_relations < num_dim)
+        assert (num_affine_relations < num_dim)
 
         if num_affine_relations == 0:
             z_new = self.union_component_wise(other)
@@ -1552,7 +1552,8 @@ class Zonotope_Net:
         A = self.net.bias_free_layers[idx_layer](z.A)
         z_new = self.relaxation_type(a0, A)
 
-        self.relaxation_at_layers.append(z_new)
+        # self.relaxation_at_layers.append(z_new)
+        self.relaxation_at_layers[-1] = z_new
 
     def apply_convolutional_layer(self, idx_layer):
         self.apply_linear_layer(idx_layer)
@@ -1649,7 +1650,8 @@ class Zonotope_Net:
 
         z_new = self.relaxation_type(a0, A)
 
-        self.relaxation_at_layers.append(z_new)
+        # self.relaxation_at_layers.append(z_new)
+        self.relaxation_at_layers[-1] = z_new
 
     def apply_maxpool_layer(self, idx_layer):
         z = self.relaxation_at_layers[-1]
@@ -1769,7 +1771,7 @@ class Zonotope_Net:
 
     def calculate_worst_case(self, true_label, label_maximization=True):
         z = self.relaxation_at_layers[-1]
-        
+
         A_diff = z.A - z.A[:, [true_label]]
         A_diff_abs = torch.sum(A_diff.abs_(), 0, keepdims=True)
 
@@ -2322,10 +2324,10 @@ class Star_Net(Zonotope_Net):
                                 y_prev = y_new * strides[1] + \
                                     y_shift - padding[1]
 
-                                if(x_prev < 0 or x_prev >= shape_prev[1]):
+                                if (x_prev < 0 or x_prev >= shape_prev[1]):
                                     continue
 
-                                if(y_prev < 0 or y_prev >= shape_prev[2]):
+                                if (y_prev < 0 or y_prev >= shape_prev[2]):
                                     continue
 
                                 idx_prev = index_i_factor_prev * c_prev + \
@@ -2478,8 +2480,8 @@ class Star_Net(Zonotope_Net):
                     logger.error('MILP Status: Interrupted')
                     raise RuntimeError
             else:
-                assert(upper_bound[idx_neuron] - val >= -1E-5)
-                assert(lower_bound[idx_neuron] - val <= 1E-5)
+                assert (upper_bound[idx_neuron] - val >= -1E-5)
+                assert (lower_bound[idx_neuron] - val <= 1E-5)
                 upper_bound[idx_neuron] = val
                 if model.Status == GRB.TIME_LIMIT:
                     logger.warn(
@@ -2503,8 +2505,8 @@ class Star_Net(Zonotope_Net):
                     logger.error('MILP Status: Interrupted')
                     raise RuntimeError
             else:
-                assert(upper_bound[idx_neuron] - val >= -1E-5)
-                assert(lower_bound[idx_neuron] - val <= 1E-5)
+                assert (upper_bound[idx_neuron] - val >= -1E-5)
+                assert (lower_bound[idx_neuron] - val <= 1E-5)
                 lower_bound[idx_neuron] = val
                 if model.Status == GRB.TIME_LIMIT:
                     logger.warn('Timelimit hit while tightening bounds',

--- a/templates.py
+++ b/templates.py
@@ -53,10 +53,9 @@ def shrinking_one(input, noise, net, label, relu_transformer, up=1.0, low=1E-3, 
         if isVerified:
             relaxations_net_verified = relaxation_net
 
-    isVerified = relaxations_net_verified is not None    
-    
-    return isVerified, relaxations_net_verified
+    isVerified = relaxations_net_verified is not None
 
+    return isVerified, relaxations_net_verified
 
 
 class OnlineTemplates:
@@ -74,8 +73,9 @@ class OnlineTemplates:
 
         input_list, noise_list = self._get_input_and_noise(inputs, method)
 
-        for input, noise in zip(input_list, noise_list):            
-            isVerified, relaxation_net = shrinking_one(input, noise, self.net, self.label, self.relu_transformer)
+        for input, noise in zip(input_list, noise_list):
+            isVerified, relaxation_net = shrinking_one(
+                input, noise, self.net, self.label, self.relu_transformer)
             if not isVerified:
                 continue
             relaxations = relaxation_net.relaxation_at_layers[1:]
@@ -370,7 +370,6 @@ class OfflineTemplates:
         if max_epsilon:
             naming += '_max'
 
-        
         prefix = path + '/intermediate_zonotopes/' + naming
 
         relaxation_list = []
@@ -388,8 +387,8 @@ class OfflineTemplates:
 
             data_loader = torch.utils.data.DataLoader(intermediate_dataset, batch_size=1,
                                                       shuffle=False, num_workers=0,
-                                                    #   collate_fn=utils.custom_collate)
-                                                    collate=custom_collate)
+                                                      #   collate_fn=utils.custom_collate)
+                                                      collate=custom_collate)
             num_samples = len(data_loader)
 
             for relaxations, label, isPredicted, isVerified in tqdm(data_loader):
@@ -419,10 +418,10 @@ class OfflineTemplates:
                     self.net(inputs), 1) == labels).item()
                 label = labels.item()
 
-
                 if max_epsilon:
                     isVerified, relaxation = shrinking_one(inputs,
-                                                           torch.ones_like(inputs),
+                                                           torch.ones_like(
+                                                               inputs),
                                                            self.net,
                                                            label,
                                                            self.relu_transformer)
@@ -579,7 +578,7 @@ class OfflineTemplates:
             dissimilarity, num_clusters)
 
         cluster_assignments = list(cluster_assignments)
-        assert(len(relaxations) == len(cluster_assignments))
+        assert (len(relaxations) == len(cluster_assignments))
 
         true_num_clusters = len(set(cluster_assignments)) - \
             (1 if -1 in cluster_assignments else 0)


### PR DESCRIPTION
Instead of accumulating the explored neurons, just keep the information 1 layer before the current layer to save memory space.